### PR TITLE
Added gpu device option

### DIFF
--- a/include/backend/screen.h
+++ b/include/backend/screen.h
@@ -12,7 +12,7 @@ struct fb;
  * the Wayland compositor is presented.
  */
 
-struct screen *screen_setup(void (*vblank_notify)(int,unsigned int,unsigned int,
+struct screen *screen_setup(char *gdevpath, void (*vblank_notify)(int,unsigned int,unsigned int,
 unsigned int, void*, bool), void *user_data, bool dmabuf_mod);
 
 void drm_handle_event(int fd);

--- a/include/swvkc.h
+++ b/include/swvkc.h
@@ -1,6 +1,6 @@
 #include <stdint.h>
 
-int swvkc_initialize(char *kdevpath, char *pdevpath);
+int swvkc_initialize(char *gdevpath, char *kdevpath, char *pdevpath);
 void swvkc_run();
 void swvkc_terminate();
 

--- a/src/backend/screen.c
+++ b/src/backend/screen.c
@@ -92,13 +92,13 @@ struct screen {
 	bool pending_page_flip;
 };
 
-int drm_setup(struct screen *);
+int drm_setup(char *gdevpath, struct screen *);
 struct fb *screen_fb_create_main(struct screen *screen, int width, int height,
 bool linear, bool no_alpha);
 void screen_fb_destroy(struct screen *screen, struct fb *fb);
 const char *conn_get_name(uint32_t type_id);
 
-struct screen *screen_setup(void (*vblank_notify)(int,unsigned int,unsigned int,
+struct screen *screen_setup(char *gdevpath, void (*vblank_notify)(int,unsigned int,unsigned int,
 unsigned int, void*, bool), void *user_data, bool dmabuf_mod) {
 	printf("├─ VIDEO (Direct Rendering Manager)\n");
 	struct screen *screen = calloc(1, sizeof(struct screen));
@@ -106,7 +106,7 @@ unsigned int, void*, bool), void *user_data, bool dmabuf_mod) {
 	screen->vblank_notify = vblank_notify;
 	screen->user_data = user_data;
 
-	if (drm_setup(screen) < 0) {
+	if (drm_setup(gdevpath, screen) < 0) {
 		return NULL;
 	}
 
@@ -224,8 +224,13 @@ static int read_cache(uint32_t *connector_id, uint32_t *crtc_id) {
 	return 0;
 }
 
-int drm_setup(struct screen *S) {
-	char *devpath = boot_gpu_devpath();
+int drm_setup(char *gdevpath, struct screen *S) {
+	char *devpath;
+	if (gdevpath) {
+		devpath = gdevpath;
+	} else {
+		devpath = boot_gpu_devpath();
+	}
 	if (!devpath) {
 		fprintf(stderr, "No suitable DRM device found");
 		return -1;

--- a/src/main.c
+++ b/src/main.c
@@ -20,7 +20,7 @@ static void spawn_client(char **argv) {
 	}
 }
 
-const char *usage = "usage: swvkc [-k <devpath>] [-p <devpath>] [client]\n\
+const char *usage = "usage: swvkc [-g <devpath>] [-k <devpath>] [-p <devpath>] [client]\n\
 \n\
 Experimental Wayland compositor\n\
 \n\
@@ -29,15 +29,17 @@ positional arguments:\n\
 \n\
 optional arguments:\n\
   -h                    show this help message and exit\n\
+  -g <devpath>          gpu device node\n\
   -k <devpath>          keyboard device node\n\
   -p <devpath>          pointer device node\n";
 
 int main(int argc, char *argv[]) {
-	char *kdevpath = NULL, *pdevpath = NULL;
+	char *gdevpath = NULL, *kdevpath = NULL, *pdevpath = NULL;
 
 	int opt;
-	while ((opt = getopt(argc, argv, "hk:p:")) != -1) {
+	while ((opt = getopt(argc, argv, "hg:k:p:")) != -1) {
 		switch (opt) {
+		case 'g': gdevpath = optarg; break;
 		case 'k': kdevpath = optarg; break;
 		case 'p': pdevpath = optarg; break;
 		default:
@@ -46,12 +48,14 @@ int main(int argc, char *argv[]) {
 		}
 	}
 
+	if (gdevpath)
+	printf("%s\n", gdevpath);
 	if (kdevpath)
 	printf("%s\n", kdevpath);
 	if (pdevpath)
 	printf("%s\n", pdevpath);
 
-	if (swvkc_initialize(kdevpath, pdevpath))
+	if (swvkc_initialize(strdup(gdevpath), kdevpath, pdevpath))
 		return EXIT_FAILURE;
 
 	if (argc > optind)

--- a/src/swvkc.c
+++ b/src/swvkc.c
@@ -112,7 +112,7 @@ int timed_commit(void *data) {
 }
 
 static struct server *swvkc; //TODO
-int swvkc_initialize(char *kdevpath, char *pdevpath) {
+int swvkc_initialize(char *gdevpath, char *kdevpath, char *pdevpath) {
 	struct server *server = calloc(1, sizeof(struct server));
 	swvkc = server;
 	wl_list_init(&server->mapped_surfaces_list);
@@ -125,7 +125,7 @@ int swvkc_initialize(char *kdevpath, char *pdevpath) {
 		return EXIT_FAILURE;
 	}
 
-	server->screen = screen_setup(vblank_notify, server, dmabuf_mod);
+	server->screen = screen_setup(gdevpath, vblank_notify, server, dmabuf_mod);
 	if (!server->screen) {
 		errlog("Could not setup screen");
 		return EXIT_FAILURE;


### PR DESCRIPTION
This is a little hack and I'm not sure whether or not you want it merged. I need it as my operating system uses [libudev-zero](https://github.com/illiliti/libudev-zero) (a daemon-less libudev replacement) which doesn't implement all the features of udev so I have to manually specify the card to get it to work though it does work which I'm mildly surprised about. The thing that concerns me most in the patch is the duplicate branching in `drm_setup` to handle the freeing of `devpath` though I can't think of a better way of handling it.